### PR TITLE
Update manifest host permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
 	"name": "Teams Copilot",
 	"description": "Extract chat from the Microsoft Teams Web and suggest responses using OpenAI's GPT.",
-	"version": "1.0",
+        "version": "1.1",
 	"author": "Qianggong (Norman) Zhang",
 
 	"background": {
@@ -17,8 +17,10 @@
 		"storage"
 	],
 
-	"host_permissions": [
-    	"https://teams.microsoft.com/*"
+        "host_permissions": [
+        "https://teams.microsoft.com/*",
+        "https://web.telegram.org/*",
+        "https://app.slack.com/*"
     ],
 
 	"action": {


### PR DESCRIPTION
## Summary
- increment manifest version
- allow Telegram and Slack web URLs

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c9c3c813c8329b09965a5203a65b5