### PR TITLE
Handle missing display name

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 2. **Configure API Key and Name**:
    - Right-click the TeamsCopilot icon in the toolbar and select **Options**.
    - Enter your OpenAI API key and your display name as it appears in Microsoft Teams.
+   - If you leave the name blank, you'll be prompted to set it when generating suggestions.
    
 
 

--- a/openai.js
+++ b/openai.js
@@ -20,7 +20,11 @@ async function loadSettings() {
 async function openai_generateVariations(chat_history, text) {
     const settings = await loadSettings();
     const apiKey = settings.apiKey;
-    const userName = settings.userName || 'Norman Zhang'; // Default to 'You' if userName is not set
+    const userName = settings.userName || '';
+
+    if (!userName) {
+        throw new Error('Teams display name not found. Please set it in the extension options.');
+    }
 
     if (!apiKey) {
         throw new Error('OpenAI API key not found. Please set it in the extension options.');


### PR DESCRIPTION
## Summary
- remove default display name from OpenAI helper
- show an error if no name is configured
- document new prompt in README

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c9f3ff61883298ab3d51d4d826342