### PR TITLE
Add platform modules and modularize popup

### DIFF
--- a/payload.js
+++ b/payload.js
@@ -1,94 +1,26 @@
 // payload.js
 
-// Function to extract chat content
+// Function to extract chat content using registered platform modules
 function extractChatContent() {
-    // Try to detect if this is a Microsoft Teams chat
-    const teamsChatContainer = document.querySelector('div[data-tid="message-pane-list-runway"]');
-    if (teamsChatContainer) {
-        return extractTeamsChat(teamsChatContainer);
+    if (!window.platformModules) {
+        console.warn('No platform modules registered');
+        return [];
     }
 
-    // Try to detect if this is a Telegram chat
-    const telegramChatContainer = document.querySelector('div.message');
-    if (telegramChatContainer) {
-        return extractTelegramChat();
-    }
-
-    console.warn("This does not appear to be a recognized chat window");
-    return [];
-}
-
-function extractTeamsChat(chatContainer) {
-    const chatItems = chatContainer.querySelectorAll('div[data-tid="chat-pane-item"]');
-    const chatHistory = [];
-
-    chatItems.forEach((chatItem) => {
-        const senderElement = chatItem.querySelector('span[data-tid="message-author-name"]');
-        const sender = senderElement ? senderElement.innerText : "Unknown Sender";
-
-        const timestampElement = chatItem.querySelector('time');
-        const timestamp = timestampElement ? timestampElement.getAttribute('aria-label') : "Unknown Time";
-
-        const messageContentElement = chatItem.querySelector('div[data-tid="chat-pane-message"]');
-        let messageContent = messageContentElement ? extractTextWithSpans(messageContentElement).trim() : "No Content";
-
-        if (sender !== "Unknown Sender" || timestamp !== "Unknown Time" || messageContent !== "No Content") {
-            chatHistory.push({ sender, timestamp, content: messageContent });
-        }
-    });
-
-    return chatHistory;
-}
-
-function extractTelegramChat() {
-    const chatItems = document.querySelectorAll('div.message.spoilers-container');
-    const chatHistory = [];
-
-    chatItems.forEach((chatItem) => {
-        let messageContent = "";
-        const translatableMessage = chatItem.querySelector('span.translatable-message');
-        if (translatableMessage) {
-            messageContent = translatableMessage.innerText.trim();
-        } else {
-            messageContent = chatItem.childNodes[0]?.nodeValue?.trim() || "No Content";
-        }
-
-        const timestampElement = chatItem.querySelector('span.i18n');
-        const timestamp = timestampElement ? timestampElement.innerText.trim() : "Unknown Time";
-
-        const sender = translatableMessage ? "Peer" : "Myself";
-
-        if (messageContent !== "No Content") {
-            chatHistory.push({ sender, timestamp, content: messageContent });
-        }
-    });
-
-    return chatHistory;
-}
-
-// Helper function to extract text from an element, handling spans with 'title' attributes
-function extractTextWithSpans(element) {
-    let text = '';
-
-    element.childNodes.forEach((node) => {
-        if (node.nodeType === Node.TEXT_NODE) {
-            // Regular text node
-            text += node.textContent;
-        } else if (node.nodeType === Node.ELEMENT_NODE) {
-            if (node.tagName.toLowerCase() === 'span' && node.getAttribute('title')) {
-                // Span element with a 'title' attribute (e.g., an emoji)
-                text += node.getAttribute('title');
-            } else if (node.tagName.toLowerCase() === 'img' && node.getAttribute('alt')) {
-                // Image element with an 'alt' attribute
-                text += node.getAttribute('alt');
-            } else {
-                // Recursively extract text from child elements
-                text += extractTextWithSpans(node);
+    for (const mod of window.platformModules) {
+        try {
+            if (typeof mod.isActivePage === 'function' && mod.isActivePage()) {
+                if (typeof mod.extractChatHistory === 'function') {
+                    return mod.extractChatHistory();
+                }
             }
+        } catch (e) {
+            console.error('Error detecting platform', e);
         }
-    });
+    }
 
-    return text;
+    console.warn('This does not appear to be a recognized chat window');
+    return [];
 }
 
 // Send the chat content as a Chrome message

--- a/platforms/slack.js
+++ b/platforms/slack.js
@@ -1,0 +1,35 @@
+(function() {
+    const module = {
+        isActivePage() {
+            return !!document.querySelector('div.p-workspace') && !!document.querySelector('div[role="textbox"]');
+        },
+        extractChatHistory() {
+            const messageNodes = document.querySelectorAll('[data-qa="message_container"]');
+            const chatHistory = [];
+            messageNodes.forEach((msg) => {
+                const sender = msg.querySelector('a.c-message__sender_link')?.innerText || 'Unknown Sender';
+                const timestampEl = msg.querySelector('a.c-timestamp, span.c-timestamp');
+                const timestamp = timestampEl ? timestampEl.getAttribute('aria-label') || timestampEl.innerText : 'Unknown Time';
+                const contentElement = msg.querySelector('[data-qa="message-text"], span.c-message__body');
+                const content = contentElement ? contentElement.innerText.trim() : 'No Content';
+                if (content !== 'No Content') {
+                    chatHistory.push({ sender, timestamp, content });
+                }
+            });
+            return chatHistory;
+        },
+        getInputText() {
+            const textbox = document.querySelector('div[role="textbox"]');
+            return textbox ? textbox.textContent.trim() : null;
+        },
+        setInputText(newText) {
+            const textbox = document.querySelector('div[role="textbox"]');
+            if (textbox) {
+                textbox.textContent = newText;
+            }
+        }
+    };
+
+    window.platformModules = window.platformModules || [];
+    window.platformModules.push(module);
+})();

--- a/platforms/teams.js
+++ b/platforms/teams.js
@@ -1,0 +1,61 @@
+(function() {
+    function extractTextWithSpans(element) {
+        let text = '';
+        element.childNodes.forEach((node) => {
+            if (node.nodeType === Node.TEXT_NODE) {
+                text += node.textContent;
+            } else if (node.nodeType === Node.ELEMENT_NODE) {
+                if (node.tagName.toLowerCase() === 'span' && node.getAttribute('title')) {
+                    text += node.getAttribute('title');
+                } else if (node.tagName.toLowerCase() === 'img' && node.getAttribute('alt')) {
+                    text += node.getAttribute('alt');
+                } else {
+                    text += extractTextWithSpans(node);
+                }
+            }
+        });
+        return text;
+    }
+
+    const module = {
+        isActivePage() {
+            return !!document.querySelector('div[data-tid="message-pane-list-runway"]');
+        },
+        extractChatHistory() {
+            const chatContainer = document.querySelector('div[data-tid="message-pane-list-runway"]');
+            if (!chatContainer) return [];
+            const chatItems = chatContainer.querySelectorAll('div[data-tid="chat-pane-item"]');
+            const chatHistory = [];
+            chatItems.forEach((chatItem) => {
+                const senderElement = chatItem.querySelector('span[data-tid="message-author-name"]');
+                const sender = senderElement ? senderElement.innerText : 'Unknown Sender';
+                const timestampElement = chatItem.querySelector('time');
+                const timestamp = timestampElement ? timestampElement.getAttribute('aria-label') : 'Unknown Time';
+                const messageContentElement = chatItem.querySelector('div[data-tid="chat-pane-message"]');
+                let messageContent = messageContentElement ? extractTextWithSpans(messageContentElement).trim() : 'No Content';
+                if (sender !== 'Unknown Sender' || timestamp !== 'Unknown Time' || messageContent !== 'No Content') {
+                    chatHistory.push({ sender, timestamp, content: messageContent });
+                }
+            });
+            return chatHistory;
+        },
+        getInputText() {
+            const textarea = document.querySelector('[data-tid="ckeditor"][contenteditable="true"]');
+            return textarea ? textarea.textContent.trim() : null;
+        },
+        setInputText(newText) {
+            const textarea = document.querySelector('[data-tid="ckeditor"][contenteditable="true"]');
+            if (textarea) {
+                const editorInstance = textarea.ckeditorInstance || textarea.ckeditor || textarea.dataset.ckeditorInstance;
+                if (editorInstance && editorInstance.setData) {
+                    editorInstance.setData(newText);
+                } else {
+                    textarea.textContent = newText;
+                }
+            }
+        }
+    };
+
+    window.platformModules = window.platformModules || [];
+    window.platformModules.push(module);
+})();

--- a/platforms/telegram.js
+++ b/platforms/telegram.js
@@ -1,0 +1,40 @@
+(function() {
+    const module = {
+        isActivePage() {
+            return !!document.querySelector('div.input-message-input');
+        },
+        extractChatHistory() {
+            const chatItems = document.querySelectorAll('div.message.spoilers-container');
+            const chatHistory = [];
+            chatItems.forEach((chatItem) => {
+                let messageContent = '';
+                const translatableMessage = chatItem.querySelector('span.translatable-message');
+                if (translatableMessage) {
+                    messageContent = translatableMessage.innerText.trim();
+                } else {
+                    messageContent = chatItem.childNodes[0]?.nodeValue?.trim() || 'No Content';
+                }
+                const timestampElement = chatItem.querySelector('span.i18n');
+                const timestamp = timestampElement ? timestampElement.innerText.trim() : 'Unknown Time';
+                const sender = translatableMessage ? 'Peer' : 'Myself';
+                if (messageContent !== 'No Content') {
+                    chatHistory.push({ sender, timestamp, content: messageContent });
+                }
+            });
+            return chatHistory;
+        },
+        getInputText() {
+            const textarea = document.querySelector('div.input-message-input');
+            return textarea ? textarea.textContent.trim() : null;
+        },
+        setInputText(newText) {
+            const textarea = document.querySelector('div.input-message-input');
+            if (textarea) {
+                textarea.textContent = newText;
+            }
+        }
+    };
+
+    window.platformModules = window.platformModules || [];
+    window.platformModules.push(module);
+})();


### PR DESCRIPTION
## Summary
- introduce modular platform support under `platforms/`
- rework `payload.js` to use platform modules to detect the current chat app
- load all platform modules from the popup and use them for text extraction/insertion

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c9f3903a48329a15b95b410e70867