### PR TITLE
Add fetch response error handling

### DIFF
--- a/openai.js
+++ b/openai.js
@@ -83,6 +83,10 @@ async function openai_generateVariations(chat_history, text) {
         }),
     });
 
+    if (!response.ok) {
+        throw new Error(response.statusText);
+    }
+
     const data = await response.json();
 
     if (data.error) {


### PR DESCRIPTION
## Summary
- check `response.ok` after calling the OpenAI API and throw an error if it fails

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c9f45c46c8329960066b6ee2387b2