### PR TITLE
Add basic unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@
 - **Keywords**: "project update [formal]" → *Generates a formal update message about the project.*
 - **Draft Input**: "Could you provide more details on" → *TeamsCopilot completes the sentence in a polished, professional tone.*
 
+## Running Tests
+
+Node's built-in test runner is used for unit tests. From the repository root, run:
+
+```bash
+node --test
+```
+
+All tests should pass and you'll see a summary of the results in the terminal.
+
 ## License
 
 This project is licensed under the Apache License 2.0.

--- a/openai.js
+++ b/openai.js
@@ -105,3 +105,8 @@ async function openai_generateVariations(chat_history, text) {
         throw new Error('No response from OpenAI API');
     }
 }
+
+// Export functions when running in a Node environment for testing purposes
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { openai_generateVariations, loadSettings };
+}

--- a/tests/openai.test.js
+++ b/tests/openai.test.js
@@ -1,0 +1,39 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { openai_generateVariations } = require('../openai.js');
+
+function setupChrome(apiKey, userName) {
+  global.chrome = {
+    storage: {
+      local: {
+        get: (_keys, cb) => cb({ openaiApiKey: apiKey, teamsUserName: userName })
+      }
+    },
+    runtime: {}
+  };
+}
+
+test('openai_generateVariations rejects without credentials', async () => {
+  setupChrome(undefined, undefined);
+  await assert.rejects(() => openai_generateVariations('', ''), /Teams display name not found/);
+});
+
+test('openai_generateVariations rejects on http error', async () => {
+  setupChrome('key', 'Alice');
+  global.fetch = async () => ({ ok: false, statusText: 'Bad Request' });
+  await assert.rejects(() => openai_generateVariations('h', 't'), /Bad Request/);
+});
+
+test('openai_generateVariations returns variations', async () => {
+  setupChrome('key', 'Alice');
+  global.fetch = async () => ({
+    ok: true,
+    json: async () => ({ choices: [
+      { message: { content: 'A' } },
+      { message: { content: 'B' } },
+      { message: { content: 'C' } }
+    ]})
+  });
+  const vars = await openai_generateVariations('history', 'text');
+  assert.deepStrictEqual(vars, ['A','B','C']);
+});

--- a/tests/platforms.test.js
+++ b/tests/platforms.test.js
@@ -1,0 +1,150 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+function loadTeamsModule() {
+  const messageContent = {
+    childNodes: [
+      { nodeType: 3, textContent: 'Hello ' },
+      { nodeType: 1, tagName: 'span', getAttribute: attr => attr === 'title' ? 'World' : null }
+    ]
+  };
+
+  const chatItem = {
+    querySelector(selector) {
+      if (selector === 'span[data-tid="message-author-name"]') {
+        return { innerText: 'Alice' };
+      }
+      if (selector === 'time') {
+        return { getAttribute: () => '1:00 PM' };
+      }
+      if (selector === 'div[data-tid="chat-pane-message"]') {
+        return messageContent;
+      }
+      return null;
+    }
+  };
+
+  const chatContainer = {
+    querySelectorAll(selector) {
+      if (selector === 'div[data-tid="chat-pane-item"]') {
+        return [chatItem];
+      }
+      return [];
+    }
+  };
+
+  global.window = { platformModules: [] };
+  global.Node = { TEXT_NODE: 3, ELEMENT_NODE: 1 };
+  global.document = {
+    querySelector(selector) {
+      if (selector === 'div[data-tid="message-pane-list-runway"]') {
+        return chatContainer;
+      }
+      return null;
+    }
+  };
+
+  delete require.cache[require.resolve('../platforms/teams.js')];
+  require('../platforms/teams.js');
+  return global.window.platformModules[0];
+}
+
+function loadTelegramModule() {
+  const chatItem = {
+    querySelector(selector) {
+      if (selector === 'span.translatable-message') {
+        return { innerText: 'Hi' };
+      }
+      if (selector === 'span.i18n') {
+        return { innerText: '1:01 PM' };
+      }
+      return null;
+    },
+    childNodes: []
+  };
+
+  global.window = { platformModules: [] };
+  global.Node = { TEXT_NODE: 3, ELEMENT_NODE: 1 };
+  global.document = {
+    querySelector(selector) {
+      if (selector === 'div.input-message-input') {
+        return {};
+      }
+      return null;
+    },
+    querySelectorAll(selector) {
+      if (selector === 'div.message.spoilers-container') {
+        return [chatItem];
+      }
+      return [];
+    }
+  };
+
+  delete require.cache[require.resolve('../platforms/telegram.js')];
+  require('../platforms/telegram.js');
+  return global.window.platformModules[0];
+}
+
+function loadSlackModule() {
+  const messageNode = {
+    querySelector(selector) {
+      if (selector === 'a.c-message__sender_link') {
+        return { innerText: 'Bob' };
+      }
+      if (selector === 'a.c-timestamp, span.c-timestamp') {
+        return { getAttribute: () => '1:02 PM', innerText: '1:02 PM' };
+      }
+      if (selector === '[data-qa="message-text"], span.c-message__body') {
+        return { innerText: 'Slack message' };
+      }
+      return null;
+    }
+  };
+
+  global.window = { platformModules: [] };
+  global.Node = { TEXT_NODE: 3, ELEMENT_NODE: 1 };
+  global.document = {
+    querySelector(selector) {
+      if (selector === 'div.p-workspace') return {};
+      if (selector === 'div[role="textbox"]') return {};
+      return null;
+    },
+    querySelectorAll(selector) {
+      if (selector === '[data-qa="message_container"]') {
+        return [messageNode];
+      }
+      return [];
+    }
+  };
+
+  delete require.cache[require.resolve('../platforms/slack.js')];
+  require('../platforms/slack.js');
+  return global.window.platformModules[0];
+}
+
+test('Teams chat extraction', () => {
+  const teams = loadTeamsModule();
+  assert.strictEqual(teams.isActivePage(), true);
+  const history = teams.extractChatHistory();
+  assert.deepStrictEqual(history, [
+    { sender: 'Alice', timestamp: '1:00 PM', content: 'Hello World' }
+  ]);
+});
+
+test('Telegram chat extraction', () => {
+  const telegram = loadTelegramModule();
+  assert.strictEqual(telegram.isActivePage(), true);
+  const history = telegram.extractChatHistory();
+  assert.deepStrictEqual(history, [
+    { sender: 'Peer', timestamp: '1:01 PM', content: 'Hi' }
+  ]);
+});
+
+test('Slack chat extraction', () => {
+  const slack = loadSlackModule();
+  assert.strictEqual(slack.isActivePage(), true);
+  const history = slack.extractChatHistory();
+  assert.deepStrictEqual(history, [
+    { sender: 'Bob', timestamp: '1:02 PM', content: 'Slack message' }
+  ]);
+});


### PR DESCRIPTION
## Summary
- export functions from `openai.js` when running in Node
- add unit tests for platform chat extraction and OpenAI logic
- document how to run the tests using Node's built-in runner

## Testing
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_685c9081a3288329a204de9d1575aa4f